### PR TITLE
File types centralized#88

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Extensions\MultiThreading.cs" />
     <Compile Include="Extensions\TreeViewExtensions.cs" />
     <Compile Include="Helpers\EnumHelpers.cs" />
+    <Compile Include="Helpers\FileHelper.cs" />
     <Compile Include="Helpers\FileStorageSize.cs" />
     <Compile Include="Helpers\FileToIconConverter.cs" />
     <Compile Include="Helpers\IoHelper.cs" />
@@ -72,6 +73,7 @@
     </Compile>
     <Compile Include="Models\FileData.cs" />
     <Compile Include="Models\FileType.cs" />
+    <Compile Include="Models\FileTypeMimeData.cs" />
     <Compile Include="Models\IconSize.cs" />
     <Compile Include="Models\ImageList.cs" />
     <Compile Include="Models\IMultiValueConverter.cs" />

--- a/Common/Extensions/FileDataExtensions.cs
+++ b/Common/Extensions/FileDataExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Common.Models;
+﻿using Common.Helpers;
+using Common.Models;
 
 namespace Common.Extensions
 {
@@ -6,32 +7,7 @@ namespace Common.Extensions
     {
         public static FileType GetFileType(this FileData fileData)
         {
-            string fileName = fileData.Path;
-            string str = Constants.ApplicationUnknown;
-            string lower = System.IO.Path.GetExtension(fileName).ToLower();
-            if (lower.Equals(string.Empty) && System.IO.Directory.Exists(fileName))
-            {
-                str = string.Empty;
-            }
-            else
-            {
-                Microsoft.Win32.RegistryKey registryKey = Microsoft.Win32.Registry.ClassesRoot.OpenSubKey(lower);
-                if (registryKey != null && registryKey.GetValue(Constants.ContentType) != null)
-                    str = registryKey.GetValue(Constants.ContentType).ToString().ToLowerInvariant();
-            }
-            if (str.Contains(Constants.ImageWord))
-                return FileType.Image;
-            if (str.Contains(Constants.TextWord) || lower.Equals(Constants.RichTextExtension))
-                return FileType.Text;
-            if (str.Contains(Constants.AudioWord) || str.Contains(Constants.VideoWord))
-                return FileType.Media;
-            if (str.Contains(Constants.ApplicationWord) && !str.Contains(Constants.ZipExtension.Replace(Constants.ExtensionSeparator, string.Empty)))
-                return FileType.Application;
-            if (str.Contains(Constants.ZipExtension.Replace(Constants.ExtensionSeparator, string.Empty)))
-                return FileType.Zip;
-            if (str.Equals(string.Empty))
-                return FileType.Folder;
-            return FileType.Unknown;
+            return FileHelper.GetFileTypeFromPath(fileData.Path);
         }
     }
 }

--- a/Common/Helpers/FileHelper.cs
+++ b/Common/Helpers/FileHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -32,6 +33,80 @@ namespace Common.Helpers
                 return FileType.Zip;
 
             return FileType.Unknown;
+        }
+
+        public static string GetFileName(string path)
+        {
+            try
+            {
+                return System.IO.Path.GetFileName(path);
+            }
+            catch (PathTooLongException ex)
+            {
+                char pathSeparator = System.IO.Path.DirectorySeparatorChar;
+                int dirSeperatorIndex = path.LastIndexOf(pathSeparator);
+
+                return path.Remove(0, dirSeperatorIndex).Trim(new char[] { ' ', pathSeparator });
+            }
+        }
+
+        public static string GetFileExtension(string path)
+        {
+            try
+            {
+                return System.IO.Path.GetExtension(path);
+            }catch(PathTooLongException ex)
+            {
+                string fileName = FileHelper.GetFileName(path);
+
+                return fileName.Remove(0, fileName.LastIndexOf('.'));
+            }
+        }
+
+        public static string GetFileNameWithoutExtension(string path)
+        {
+            try
+            {
+                return System.IO.Path.GetFileNameWithoutExtension(FileHelper.GetFileName(path));
+            }catch(PathTooLongException ex)
+            {
+                string fileName = FileHelper.GetFileName(path);
+                int extensionIndex = fileName.LastIndexOf('.');
+
+                return fileName.Substring(0, extensionIndex);
+            }
+        }
+
+        public static string GetDirectoryName(string path)
+        {
+            try
+            {
+                return System.IO.Path.GetDirectoryName(path);
+            }catch(PathTooLongException ex)
+            {
+                return path.Replace(FileHelper.GetFileName(path), "");
+            }
+        }
+
+        public static string GetCurrentDirectoryName(string path)
+        {
+            char pathSeparator = System.IO.Path.DirectorySeparatorChar;
+
+            return FileHelper.GetFileName(path.Replace(FileHelper.GetFileName(path), "").Trim(new char[] { ' ', pathSeparator })) + pathSeparator;
+        }
+
+        public static bool PathHasExtension(string path)
+        {
+            try
+            {
+                return System.IO.Path.HasExtension(path);
+            }catch(PathTooLongException ex)
+            {
+                string fileName = FileHelper.GetFileName(path);
+                string extension = fileName.Remove(0, fileName.LastIndexOf('.'));
+
+                return !string.IsNullOrWhiteSpace(extension.Trim(new char[] { '.' }));
+            }
         }
     }
 }

--- a/Common/Helpers/FileHelper.cs
+++ b/Common/Helpers/FileHelper.cs
@@ -1,0 +1,37 @@
+﻿using Common.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Common.Helpers
+{
+    public static class FileHelper
+    {
+        // use FileTypeMimeData
+        public static FileType GetFileTypeFromPath(string path)
+        {
+            string mimeType = Constants.ApplicationUnknown;
+            string extension = System.IO.Path.GetExtension(path).ToLower();
+            if (extension.Equals(string.Empty) && System.IO.Directory.Exists(path))
+                return FileType.Folder;
+
+            Microsoft.Win32.RegistryKey registryKey = Microsoft.Win32.Registry.ClassesRoot.OpenSubKey(extension);
+            if (registryKey != null && registryKey.GetValue(Constants.ContentType) != null)
+                mimeType = registryKey.GetValue(Constants.ContentType).ToString().ToLowerInvariant();
+
+            if (mimeType.Contains(Constants.ImageWord))
+                return FileType.Image;
+            if (mimeType.Contains(Constants.TextWord) || extension.Equals(Constants.RichTextExtension))
+                return FileType.Text;
+            if (mimeType.Contains(Constants.AudioWord) || mimeType.Contains(Constants.VideoWord))
+                return FileType.Media;
+            if (mimeType.Contains(Constants.ApplicationWord) && !mimeType.Contains(Constants.ZipExtension.Replace(Constants.ExtensionSeparator, string.Empty)))
+                return FileType.Application;
+            if (mimeType.Contains(Constants.ZipExtension.Replace(Constants.ExtensionSeparator, string.Empty)))
+                return FileType.Zip;
+
+            return FileType.Unknown;
+        }
+    }
+}

--- a/Common/Helpers/FileHelper.cs
+++ b/Common/Helpers/FileHelper.cs
@@ -13,7 +13,7 @@ namespace Common.Helpers
         public static FileType GetFileTypeFromPath(string path)
         {
             string mimeType = Constants.ApplicationUnknown;
-            string extension = System.IO.Path.GetExtension(path).ToLower();
+            string extension = FileHelper.GetFileExtension(path).ToLower();
             if (extension.Equals(string.Empty) && System.IO.Directory.Exists(path))
                 return FileType.Folder;
 

--- a/Common/Helpers/FileToIconConverter.cs
+++ b/Common/Helpers/FileToIconConverter.cs
@@ -297,7 +297,7 @@ namespace Common.Helpers
         private Bitmap LoadJumbo(string lookup)
         {
             FileToIconConverter._imgList.ImageListSize = FileToIconConverter.IsVistaUp() ? SysImageListSize.jumbo : SysImageListSize.extraLargeIcons;
-            Icon icon = FileToIconConverter._imgList.Icon(FileToIconConverter._imgList.IconIndex(lookup, FileToIconConverter.isFolder(lookup)));
+            Icon icon = FileToIconConverter._imgList.Icon(FileToIconConverter._imgList.IconIndex(lookup, FileToIconConverter.IsFolder(lookup)));
             Bitmap imgToResize = icon.ToBitmap();
             icon.Dispose();
             Color color = Color.FromArgb(0, 0, 0, 0);
@@ -392,7 +392,7 @@ namespace Common.Helpers
             {
                 case IconSize.ExtraLarge:
                     FileToIconConverter._imgList.ImageListSize = SysImageListSize.extraLargeIcons;
-                    return FileToIconConverter.LoadBitmap(FileToIconConverter._imgList.Icon(FileToIconConverter._imgList.IconIndex(dummyFile, FileToIconConverter.isFolder(fileName))).ToBitmap());
+                    return FileToIconConverter.LoadBitmap(FileToIconConverter._imgList.Icon(FileToIconConverter._imgList.IconIndex(dummyFile, FileToIconConverter.IsFolder(fileName))).ToBitmap());
                 case IconSize.Jumbo:
                     return FileToIconConverter.LoadBitmap(this.LoadJumbo(dummyFile));
                 case IconSize.Thumbnail:

--- a/Common/Helpers/FileToIconConverter.cs
+++ b/Common/Helpers/FileToIconConverter.cs
@@ -98,11 +98,11 @@ namespace Common.Helpers
         internal static Icon GetFileIcon(string fileName, IconSize size)
         {
             SHFILEINFO psfi = new SHFILEINFO();
-            uint num = ShellIconFlags.SHGFI_SYSICONINDEX; 
+            SHGetFileInfo num = SHGetFileInfo.SHGFI_SYSICONINDEX; 
             if (fileName.IndexOf(":") == -1)
-                num |= ShellIconFlags.SHGFI_USEFILEATTRIBUTES; 
-            uint uFlags = size != IconSize.Small ? num | ShellIconFlags.SHGFI_ICON : (uint)((int)num | ShellIconFlags.SHGFI_ICON | ShellIconFlags.SHGFI_SMALLICON);
-            shell32.SHGetFileInfo(fileName, ShellIconFlags.SHGFI_LARGEICON, ref psfi, (uint)Marshal.SizeOf(psfi), uFlags);
+                num |= SHGetFileInfo.SHGFI_USEFILEATTRIBUTES;
+            SHGetFileInfo uFlags = (SHGetFileInfo)(size != IconSize.Small ? num | SHGetFileInfo.SHGFI_ICON : (num | SHGetFileInfo.SHGFI_ICON | SHGetFileInfo.SHGFI_SMALLICON));
+            shell32.SHGetFileInfo(fileName, (FileAttribute)SHGetFileInfo.SHGFI_LARGEICON, ref psfi, (uint)Marshal.SizeOf(psfi), uFlags);
             return Icon.FromHandle(psfi.hIcon);
         }
 

--- a/Common/Helpers/IoHelper.cs
+++ b/Common/Helpers/IoHelper.cs
@@ -56,14 +56,14 @@ namespace Common.Helpers
         {
             try
             {
-                if (System.IO.Directory.Exists(path))
+                if (FileHelper.DirectoryExists(path))
                 {
                     //System.IO.DirectoryInfo dirInfo = new System.IO.DirectoryInfo(path);
                     //System.Security.AccessControl.DirectorySecurity dirAC = dirInfo.GetAccessControl(System.Security.AccessControl.AccessControlSections.All);
                     System.IO.Directory.GetDirectories(path);
                     System.IO.Directory.GetFiles(path);
                 }
-                else if (System.IO.File.Exists(path))
+                else if (FileHelper.FileExists(path))
                 {
                     //System.IO.FileInfo fileInfo = new System.IO.FileInfo(path);
                     //System.Security.AccessControl.FileSecurity fileAC = fileInfo.GetAccessControl(System.Security.AccessControl.AccessControlSections.All);

--- a/Common/Models/FileData.cs
+++ b/Common/Models/FileData.cs
@@ -101,7 +101,7 @@ namespace Common.Models
                 if (string.IsNullOrEmpty(this.Path) || this.Path.Trim() == string.Empty)
                     return string.Empty;
                 if (this._name == null)
-                    this._name = System.IO.Path.GetFileNameWithoutExtension(this.Path);
+                    this._name = FileHelper.GetFileNameWithoutExtension(this.Path);
                 return this._name;
             }
             private set
@@ -116,7 +116,7 @@ namespace Common.Models
                 if (string.IsNullOrEmpty(this.Path) || this.Path.Trim() == string.Empty)
                     return string.Empty;
                 if (this._extension == null)
-                    this._extension = System.IO.Path.GetExtension(this.Path);
+                    this._extension = FileHelper.GetFileExtension(this.Path);
                 return this._extension.ToLowerInvariant();
             }
             private set
@@ -131,7 +131,7 @@ namespace Common.Models
                 if (string.IsNullOrEmpty(this.Path) || this.Path.Trim() == string.Empty)
                     return string.Empty;
                 if (this._diectory == null)
-                    this._diectory = System.IO.Path.GetDirectoryName(this.Path) + "\\";
+                    this._diectory = FileHelper.GetDirectoryName(this.Path) + "\\";
                 return this._diectory;
             }
             private set
@@ -250,7 +250,7 @@ namespace Common.Models
         {
             try
             {
-                Folder folder = this._shell.NameSpace(System.IO.Path.GetDirectoryName(this.Path));
+                Folder folder = this._shell.NameSpace(FileHelper.GetDirectoryName(this.Path));
                 return this._shell;
             }
             catch (Exception ex) { }
@@ -258,7 +258,7 @@ namespace Common.Models
             try
             {
                 this._shell = ole32.GetIShellDispatch5();
-                Folder folder = this._shell.NameSpace(System.IO.Path.GetDirectoryName(this.Path));
+                Folder folder = this._shell.NameSpace(FileHelper.GetDirectoryName(this.Path));
                 return this._shell;
             }
             catch (Exception ex) { }
@@ -269,7 +269,7 @@ namespace Common.Models
                 ole32.GetRegisteredInterfaceMarshalPtr<Shell32.IShellDispatch5>(shell);
                 GC.KeepAlive(shell);
                 this._shell = ole32.GetIShellDispatch5();
-                Folder folder = this._shell.NameSpace(System.IO.Path.GetDirectoryName(this.Path));
+                Folder folder = this._shell.NameSpace(FileHelper.GetDirectoryName(this.Path));
                 return this._shell;
             }
             catch (Exception ex) { }
@@ -298,8 +298,8 @@ namespace Common.Models
 
                         if (fileData.GetShell() != null)
                         {
-                            Folder folder = fileData._shell.NameSpace(System.IO.Path.GetDirectoryName(fileData.Path));
-                            FolderItem name = folder.ParseName(System.IO.Path.GetFileName(fileData.Path));
+                            Folder folder = fileData._shell.NameSpace(FileHelper.GetDirectoryName(fileData.Path));
+                            FolderItem name = folder.ParseName(FileHelper.GetFileName(fileData.Path));
 
                             for (int iColumn = -1; iColumn < 1000; iColumn++) //(int)short.MaxValue
                             {

--- a/Common/Models/FileTypeMimeData.cs
+++ b/Common/Models/FileTypeMimeData.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Common.Models
+{
+    public class FileTypeMimeData
+    {
+        // create a static dictionary which will act as a cache. key is file type
+
+        // create a method which allows user to populate cache
+        // populating cache would consist of reading reg keys under HKEY_ROOT.
+        // need to have a flag of "found extensions" set to false as you start reading reg.
+        // when the first reg key is found which starts with a period, set the flag to true
+        // continue reading reg keys until a key is found NOT starting with a period
+
+        // create a method which allows user to clear cache
+
+        // create a method which allows the user to add file extensions to a file type &/or a mime type
+        public FileTypeMimeData(string mimeType, string perceivedType = null)
+        {
+
+        }
+
+        public FileType FileType { get; }
+        public string MimeType { get; }
+        public IList<string> Extensions { get; }
+        public string Type { get; }
+        public string SubType { get; }
+        public string PerceivedType { get; }
+    }
+}

--- a/Common/Models/ImageList.cs
+++ b/Common/Models/ImageList.cs
@@ -82,7 +82,7 @@ namespace Common.Models.ImageList
             SHGetFileInfo fileInfoConstants = SHGetFileInfo.SHGFI_SYSICONINDEX;
             if (this.size == SysImageListSize.smallIcons)
                 fileInfoConstants |= SHGetFileInfo.SHGFI_SMALLICON;
-            uint dwFileAttributes;
+            FileAttribute dwFileAttributes;
             if (!forceLoadFromDisk)
             {
                 fileInfoConstants |= SHGetFileInfo.SHGFI_USEFILEATTRIBUTES;
@@ -92,7 +92,7 @@ namespace Common.Models.ImageList
                 dwFileAttributes = 0;
             SHFILEINFO psfi = new SHFILEINFO();
             uint cbFileInfo = (uint)Marshal.SizeOf(psfi.GetType());
-            IntPtr fileInfo = shell32.SHGetFileInfo(fileName, dwFileAttributes, ref psfi, cbFileInfo, (uint)(fileInfoConstants | (SHGetFileInfo)iconState));
+            IntPtr fileInfo = shell32.SHGetFileInfo(fileName, dwFileAttributes, ref psfi, cbFileInfo, (fileInfoConstants | (SHGetFileInfo)iconState));
             if (!fileInfo.Equals(IntPtr.Zero))
                 return (int)psfi.iIcon;
             //Debug.Assert(!fileInfo.Equals(IntPtr.Zero), "Failed to get icon index");
@@ -226,7 +226,7 @@ namespace Common.Models.ImageList
                     fileInfoConstants |= SHGetFileInfo.SHGFI_SMALLICON;
                 SHFILEINFO psfi = new SHFILEINFO();
                 uint cbFileInfo = (uint)Marshal.SizeOf(psfi.GetType());
-                this.hIml = shell32.SHGetFileInfo(".txt", FileAttribute.FILE_ATTRIBUTE_NORMAL, ref psfi, cbFileInfo, (uint)fileInfoConstants);
+                this.hIml = shell32.SHGetFileInfo(".txt", FileAttribute.FILE_ATTRIBUTE_NORMAL, ref psfi, cbFileInfo, fileInfoConstants);
                 Debug.Assert(this.hIml != IntPtr.Zero, "Failed to create Image List");
             }
         }

--- a/Common/Models/ZipExtractor/ZipFile.cs
+++ b/Common/Models/ZipExtractor/ZipFile.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Common.Helpers;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -185,8 +186,8 @@ namespace Common.Models.ZipExtractor
         {
             if (this.ArchiveStream == null)
             {
-                this.sevenZipFormat = new SevenZipLoader(System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), sevenZipDll));
-                this.Archive = sevenZipFormat.CreateInArchive(this.GetFormatFromExtension(System.IO.Path.GetExtension(this._path)).Guid);
+                this.sevenZipFormat = new SevenZipLoader(System.IO.Path.Combine(FileHelper.GetDirectoryName(Assembly.GetExecutingAssembly().Location), sevenZipDll));
+                this.Archive = sevenZipFormat.CreateInArchive(this.GetFormatFromExtension(FileHelper.GetFileExtension(this._path)).Guid);
                 if (Archive == null)
                     return null;
                 this.ArchiveStream = new InStreamWrapper(File.OpenRead(this._path));

--- a/FilePreview/BrowseFiles/FileBrowserControl.cs
+++ b/FilePreview/BrowseFiles/FileBrowserControl.cs
@@ -79,7 +79,7 @@ namespace FilePreview.BrowseFiles
                                     if (args.Token.IsCancellationRequested)
                                         break;
                                     string key = FileBrowserControl.AddImage(file, v.LargeImageList, v.LargeImageList.ImageSize);
-                                    FileBrowserControl.AddItem(v, FileHelper.GetFileName(file), key);
+                                    FileBrowserControl.AddItem(v, file, key, FileHelper.GetFileName(file));
                                     this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[file]);
                                 }
                                 catch (Exception ex) { }
@@ -91,8 +91,9 @@ namespace FilePreview.BrowseFiles
                                 {
                                     if (args.Token.IsCancellationRequested)
                                         break;
-                                    string key = FileBrowserControl.AddImage(Constants.DirectoryKey, v.LargeImageList, v.LargeImageList.ImageSize);
-                                    FileBrowserControl.AddItem(v, Constants.DirectoryKey, key);
+                                    string currentDirectory = FileHelper.GetCurrentDirectoryName(directory);
+                                    string key = FileBrowserControl.AddImage(directory + Constants.DirectoryKey, v.LargeImageList, v.LargeImageList.ImageSize);
+                                    FileBrowserControl.AddItem(v, directory + Constants.DirectoryKey, key, currentDirectory);
                                     this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[directory + Constants.DirectoryKey]);
                                 }
                                 catch (Exception ex) { }
@@ -225,7 +226,7 @@ namespace FilePreview.BrowseFiles
                     {
                         args.Token.ThrowIfCancellationRequested();
                         string key = FileBrowserControl.AddImage(file, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
-                        FileBrowserControl.AddItem(args.View, FileHelper.GetFileName(file), key);
+                        FileBrowserControl.AddItem(args.View, file, key, FileHelper.GetFileName(file));
                         this._itemGroups[this._itemGroupIndex].Items.Add(args.View.Items[file]);
                     }
                     catch (Exception) { }
@@ -235,8 +236,9 @@ namespace FilePreview.BrowseFiles
                     try
                     {
                         args.Token.ThrowIfCancellationRequested();
-                        string key = FileBrowserControl.AddImage(Constants.DirectoryKey, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
-                        FileBrowserControl.AddItem(args.View, Constants.DirectoryKey, key);
+                        string currentDirectory = FileHelper.GetCurrentDirectoryName(directory);
+                        string key = FileBrowserControl.AddImage(directory + Constants.DirectoryKey, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
+                        FileBrowserControl.AddItem(args.View, directory + Constants.DirectoryKey, key, currentDirectory);
                         this._itemGroups[this._itemGroupIndex].Items.Add(args.View.Items[directory + Constants.DirectoryKey]);
                     }
                     catch (Exception) { }
@@ -272,10 +274,12 @@ namespace FilePreview.BrowseFiles
             return key;
         }
 
-        private static void AddItem(ListView listView, string fileName, string imageKey)
+        private static void AddItem(ListView listView, string fileName, string imageKey, string text = null)
         {
             ListViewItem listViewItem = new ListViewItem(fileName, imageKey.Equals(string.Empty) ? Constants.NoneFileExtension : imageKey);
             listViewItem.Name = fileName;
+            if (text != null)
+                listViewItem.Text = text;
             listView.Items.Add(listViewItem);
         }
 

--- a/FilePreview/BrowseFiles/FileBrowserControl.cs
+++ b/FilePreview/BrowseFiles/FileBrowserControl.cs
@@ -79,7 +79,7 @@ namespace FilePreview.BrowseFiles
                                     if (args.Token.IsCancellationRequested)
                                         break;
                                     string key = FileBrowserControl.AddImage(file, v.LargeImageList, v.LargeImageList.ImageSize);
-                                    FileBrowserControl.AddItem(v, System.IO.Path.GetFileName(file), key);
+                                    FileBrowserControl.AddItem(v, FileHelper.GetFileName(file), key);
                                     this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[file]);
                                 }
                                 catch (Exception ex) { }
@@ -184,8 +184,8 @@ namespace FilePreview.BrowseFiles
                         {
                             args.Token.ThrowIfCancellationRequested();
                             string key = FileBrowserControl.AddImage(zipContent.Path, v.LargeImageList, v.LargeImageList.ImageSize);
-                            string fileName = System.IO.Path.GetFileName(zipContent.Path);
-                            string itemName = string.IsNullOrWhiteSpace(fileName) ? System.IO.Path.GetDirectoryName(zipContent.Path) : fileName;
+                            string fileName = FileHelper.GetFileName(zipContent.Path);
+                            string itemName = string.IsNullOrWhiteSpace(fileName) ? FileHelper.GetDirectoryName(zipContent.Path) : fileName;
                             FileBrowserControl.AddItem(v, itemName, key);
                             this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[zipContent.Path]);
                         }
@@ -225,7 +225,7 @@ namespace FilePreview.BrowseFiles
                     {
                         args.Token.ThrowIfCancellationRequested();
                         string key = FileBrowserControl.AddImage(file, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
-                        FileBrowserControl.AddItem(args.View, System.IO.Path.GetFileName(file), key);
+                        FileBrowserControl.AddItem(args.View, FileHelper.GetFileName(file), key);
                         this._itemGroups[this._itemGroupIndex].Items.Add(args.View.Items[file]);
                     }
                     catch (Exception) { }
@@ -281,7 +281,7 @@ namespace FilePreview.BrowseFiles
 
         private static string GetKey(string fileName)
         {
-            return !Path.GetFileName(fileName).Equals(string.Empty) || !fileName.EndsWith(Constants.DirectoryKey) ? Path.GetExtension(fileName) : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + Constants.DirectoryKey;
+            return !FileHelper.GetFileName(fileName).Equals(string.Empty) || !fileName.EndsWith(Constants.DirectoryKey) ? FileHelper.GetFileExtension(fileName) : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + Constants.DirectoryKey;
         }
 
         private class FileBrowserControlItem

--- a/FilePreview/BrowseFiles/FileBrowserControl.cs
+++ b/FilePreview/BrowseFiles/FileBrowserControl.cs
@@ -79,7 +79,7 @@ namespace FilePreview.BrowseFiles
                                     if (args.Token.IsCancellationRequested)
                                         break;
                                     string key = FileBrowserControl.AddImage(file, v.LargeImageList, v.LargeImageList.ImageSize);
-                                    FileBrowserControl.AddItem(v, file, key);
+                                    FileBrowserControl.AddItem(v, System.IO.Path.GetFileName(file), key);
                                     this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[file]);
                                 }
                                 catch (Exception ex) { }
@@ -91,8 +91,8 @@ namespace FilePreview.BrowseFiles
                                 {
                                     if (args.Token.IsCancellationRequested)
                                         break;
-                                    string key = FileBrowserControl.AddImage(directory + Constants.DirectoryKey, v.LargeImageList, v.LargeImageList.ImageSize);
-                                    FileBrowserControl.AddItem(v, directory + Constants.DirectoryKey, key);
+                                    string key = FileBrowserControl.AddImage(Constants.DirectoryKey, v.LargeImageList, v.LargeImageList.ImageSize);
+                                    FileBrowserControl.AddItem(v, Constants.DirectoryKey, key);
                                     this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[directory + Constants.DirectoryKey]);
                                 }
                                 catch (Exception ex) { }
@@ -122,7 +122,7 @@ namespace FilePreview.BrowseFiles
                             {
                                 StartInfo = {
                                     FileName = "explorer",
-                                    Arguments = ("\"" + item.Name + "\"")
+                                    Arguments = ("\"" + System.IO.Path.Combine(this.currentDirectoryTextBox.Text, item.Name) + "\"")
                                 }
                             }.Start();
                         }catch(System.ComponentModel.Win32Exception win32Ex)
@@ -184,7 +184,9 @@ namespace FilePreview.BrowseFiles
                         {
                             args.Token.ThrowIfCancellationRequested();
                             string key = FileBrowserControl.AddImage(zipContent.Path, v.LargeImageList, v.LargeImageList.ImageSize);
-                            FileBrowserControl.AddItem(v, zipContent.Path, key);
+                            string fileName = System.IO.Path.GetFileName(zipContent.Path);
+                            string itemName = string.IsNullOrWhiteSpace(fileName) ? System.IO.Path.GetDirectoryName(zipContent.Path) : fileName;
+                            FileBrowserControl.AddItem(v, itemName, key);
                             this._itemGroups[this._itemGroupIndex].Items.Add(v.Items[zipContent.Path]);
                         }
                         catch (Exception) { }
@@ -223,7 +225,7 @@ namespace FilePreview.BrowseFiles
                     {
                         args.Token.ThrowIfCancellationRequested();
                         string key = FileBrowserControl.AddImage(file, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
-                        FileBrowserControl.AddItem(args.View, file, key);
+                        FileBrowserControl.AddItem(args.View, System.IO.Path.GetFileName(file), key);
                         this._itemGroups[this._itemGroupIndex].Items.Add(args.View.Items[file]);
                     }
                     catch (Exception) { }
@@ -233,8 +235,8 @@ namespace FilePreview.BrowseFiles
                     try
                     {
                         args.Token.ThrowIfCancellationRequested();
-                        string key = FileBrowserControl.AddImage(directory + Constants.DirectoryKey, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
-                        FileBrowserControl.AddItem(args.View, directory + Constants.DirectoryKey, key);
+                        string key = FileBrowserControl.AddImage(Constants.DirectoryKey, args.View.LargeImageList, args.View.LargeImageList.ImageSize);
+                        FileBrowserControl.AddItem(args.View, Constants.DirectoryKey, key);
                         this._itemGroups[this._itemGroupIndex].Items.Add(args.View.Items[directory + Constants.DirectoryKey]);
                     }
                     catch (Exception) { }

--- a/FilePreview/TextFiles/TextFilePreview.cs
+++ b/FilePreview/TextFiles/TextFilePreview.cs
@@ -1,4 +1,5 @@
-﻿using Common.Models;
+﻿using Common.Helpers;
+using Common.Models;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -49,7 +50,7 @@ namespace FilePreview.TextFiles
                 else
                 {
                     viewer.Clear();
-                    viewer.LoadFile(path, System.IO.Path.GetExtension(path).ToLower().Equals(Common.Models.Constants.ZipExtension) ? RichTextBoxStreamType.RichText : RichTextBoxStreamType.PlainText);
+                    viewer.LoadFile(path, FileHelper.GetFileExtension(path).ToLower().Equals(Common.Models.Constants.ZipExtension) ? RichTextBoxStreamType.RichText : RichTextBoxStreamType.PlainText);
                 }
                 success = true;
             }

--- a/FilePreview/ZipFiles/ZipBrowserControl.cs
+++ b/FilePreview/ZipFiles/ZipBrowserControl.cs
@@ -218,7 +218,7 @@ namespace FilePreview.BrowseFiles
                 key = ZipBrowserControl.GetKey(path);
                 // because we are in zip file, we cant pass the folder inside the zip to get image
                 // so we pass appdata folder to get a folder image. some files dont have extension, so pass .none as extension
-                bitmap1 = fileToIconConverter.GetImage(string.IsNullOrWhiteSpace(System.IO.Path.GetFileName(path)) ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) : (path.Contains(".") ? path : ".none"), IconSize.ExtraLarge).ToBitmap(); 
+                bitmap1 = fileToIconConverter.GetImage(string.IsNullOrWhiteSpace(FileHelper.GetFileName(path)) ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) : (path.Contains(".") ? path : ".none"), IconSize.ExtraLarge).ToBitmap(); 
 
                 if (!imageList.Images.ContainsKey(key))
                     imageList.Images.Add(key, bitmap1);
@@ -237,7 +237,7 @@ namespace FilePreview.BrowseFiles
 
         private static string GetKey(string fileName)
         {
-            return !Path.GetFileName(fileName).Equals(string.Empty) || !fileName.EndsWith(Constants.DirectoryKey) ? Path.GetExtension(fileName) : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + Constants.DirectoryKey;
+            return !FileHelper.GetFileName(fileName).Equals(string.Empty) || !fileName.EndsWith(Constants.DirectoryKey) ? FileHelper.GetFileExtension(fileName) : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + Constants.DirectoryKey;
         }
 
         private class FileBrowserControlItem

--- a/Logic/ConcurrentFileSearch.cs
+++ b/Logic/ConcurrentFileSearch.cs
@@ -396,7 +396,7 @@ namespace FileList.Logic
                 }
                 catch (Exception ex)
                 {
-                    string dir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
+                    string dir = FileHelper.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
                     lock (errFileLock)
                     {
                         System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "err.txt"), ex.Message);

--- a/Logic/Mover.cs
+++ b/Logic/Mover.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Extensions;
+using Common.Helpers;
 using FileList.Models;
 using System;
 using System.Collections.Generic;
@@ -61,7 +62,7 @@ namespace FileList.Logic
                 {
                     if (!File.Exists(item))
                         throw new Exception(string.Format("The file requested does not exist: {0}", item));
-                    string destination = Path.Combine(this._destination, Path.GetFileName(item));
+                    string destination = Path.Combine(this._destination, FileHelper.GetFileName(item));
                     File.Copy(item, destination, this._overwrite);
                     this._moveProgress.InvokeIfRequired(p => p.PushMessage(string.Format("File copied: {0}", item)));
                     if (!this.ValidateCopy(item, destination))
@@ -71,11 +72,11 @@ namespace FileList.Logic
                         File.Delete(item);
                         if (File.Exists(item))
                             throw new Exception(string.Format("Could not delete file: {0}", item));
-                        string directoryName = Path.GetDirectoryName(item);
+                        string directoryName = FileHelper.GetDirectoryName(item);
                         if (Directory.GetFiles(directoryName).Length < 1)
                             Directory.Delete(directoryName);
                     }
-                    this._moveProgress.InvokeIfRequired(p => p.AddItem(item, string.Format("{0} successfully {2} to {1}", Path.GetFileName(item), destination, this.OperationText)));
+                    this._moveProgress.InvokeIfRequired(p => p.AddItem(item, string.Format("{0} successfully {2} to {1}", FileHelper.GetFileName(item), destination, this.OperationText)));
                 }
                 catch (Exception ex)
                 {
@@ -108,11 +109,11 @@ namespace FileList.Logic
                         File.Delete(item);
                         if (File.Exists(item))
                             throw new Exception(string.Format("Could not delete file: {0}", item));
-                        string directoryName = Path.GetDirectoryName(item);
+                        string directoryName = FileHelper.GetDirectoryName(item);
                         if (Directory.GetFiles(directoryName).Length < 1)
                             Directory.Delete(directoryName);
                     }
-                    this._moveProgress.InvokeIfRequired(p => p.AddItem(item, string.Format("{0} successfully {2} to {1}", Path.GetFileName(item), destination, this.OperationText)));
+                    this._moveProgress.InvokeIfRequired(p => p.AddItem(item, string.Format("{0} successfully {2} to {1}", FileHelper.GetFileName(item), destination, this.OperationText)));
                 }
                 catch (Exception ex)
                 {
@@ -138,7 +139,7 @@ namespace FileList.Logic
         private string CreateDestination(string source, string destination, ProgressInfoControl moveProgress)
         {
             string path = Path.Combine(destination, source.Replace(":", ""));
-            string directoryName = Path.GetDirectoryName(path);
+            string directoryName = FileHelper.GetDirectoryName(path);
 
             if (!Directory.Exists(directoryName))
             {

--- a/Logic/NotepadHelper.cs
+++ b/Logic/NotepadHelper.cs
@@ -6,7 +6,7 @@ namespace FileList.Logic
 {
     public static class Notepad
     {
-
+        private const int WM_SETTEXT = 0x000c;
         public static void ShowMessage(string message = null, string title = null)
         {
             Process process = Process.Start(new ProcessStartInfo("notepad.exe"));
@@ -16,7 +16,7 @@ namespace FileList.Logic
             if (!string.IsNullOrEmpty(title))
                 user32.SetWindowText(process.MainWindowHandle, title);
             if (!string.IsNullOrEmpty(message))
-                 user32.SendMessage(user32.FindWindowEx(process.MainWindowHandle, new IntPtr(0), "Edit", null), 12, 0, message);
+                user32.SendMessage(user32.FindWindowEx(process.MainWindowHandle, new IntPtr(0), "Edit", null), WM_SETTEXT, 0, message);
         }
     }
 }

--- a/Logic/UiHelper.cs
+++ b/Logic/UiHelper.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Windows.Forms;
 using System.Linq;
 using FileList.Views;
+using Common.Helpers;
 
 namespace FileList.Logic
 {
@@ -181,7 +182,7 @@ namespace FileList.Logic
         public static void OpenLocation(string path)
         {
             if (File.Exists(path))
-                UiHelper.OpenItem(path.Replace(Path.GetFileName(path), string.Empty));
+                UiHelper.OpenItem(path.Replace(FileHelper.GetFileName(path), string.Empty));
             else
                 UiHelper.OpenItem(path);
         }
@@ -273,7 +274,7 @@ namespace FileList.Logic
         public static FileType GetFileType(string fileName)
         {
             string str = "application/unknown";
-            string lower = Path.GetExtension(fileName).ToLower();
+            string lower = FileHelper.GetFileExtension(fileName).ToLower();
             if (lower.Equals(string.Empty) && Directory.Exists(fileName))
             {
                 str = string.Empty;

--- a/Logic/UiHelper.cs
+++ b/Logic/UiHelper.cs
@@ -74,10 +74,14 @@ namespace FileList.Logic
 
         public static void CancelSearch()
         {
-            if (UiHelper.worker != null && UiHelper.cancellationToken != null && !UiHelper.cancellationToken.IsCancellationRequested)
-            {
+            bool isTokenDisposed = true;
+            var privateInt = UiHelper.cancellationToken?.GetType().GetProperty("IsDisposed",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            if (privateInt != null)
+                isTokenDisposed = (bool)privateInt.GetValue(UiHelper.cancellationToken, null);
+
+            if (UiHelper.worker != null && UiHelper.cancellationToken != null && !isTokenDisposed && !UiHelper.cancellationToken.IsCancellationRequested)
                 UiHelper.cancellationToken.Cancel();
-            }
         }
 
         private static void Worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/Models/FileListControl.cs
+++ b/Models/FileListControl.cs
@@ -701,7 +701,7 @@ namespace FileList.Models
         /// <param name="tree"></param>
         private static void ScrollTreeLeft(TreeView tree)
         {
-            user32.SendMessage(tree.Handle, (uint)(int)MessageCodes.WM_HSCROLL, HorizontalScrollBarCommands.SB_LEFT, 0);
+            user32.SendMessage(tree.Handle, (uint)(int)MessageCodes.WM_HSCROLL, HorizontalScrollBarCommands.SB_LEFT, new IntPtr(0)); 
         }
 
         /// <summary>

--- a/Models/FileListControl.cs
+++ b/Models/FileListControl.cs
@@ -10,6 +10,7 @@ using Win32.Constants;
 using Win32.Libraries;
 using Common.Extensions;
 using Common.Models;
+using Common.Helpers;
 
 namespace FileList.Models
 {
@@ -188,9 +189,9 @@ namespace FileList.Models
 
             if (treeNode == null)
             {
-                parentName = System.IO.Path.GetDirectoryName(path);
-                TreeNode parentNode = this.treeView1.Nodes[System.IO.Path.GetDirectoryName(path)];
-                childName = System.IO.Path.GetFileName(path);
+                parentName = FileHelper.GetDirectoryName(path);
+                TreeNode parentNode = this.treeView1.Nodes[FileHelper.GetDirectoryName(path)];
+                childName = FileHelper.GetFileName(path);
 
                 if (parentNode.Nodes.ContainsKey(childName))
                 {
@@ -233,8 +234,8 @@ namespace FileList.Models
             {
                 if ((n.Tag as FileData?).HasValue)
                     return true;
-                if (Path.HasExtension(n.Text))
-                    return Path.GetExtension(n.Text).ToLowerInvariant().Equals(UiHelper.ZipExtension);
+                if (FileHelper.PathHasExtension(n.Text))
+                    return FileHelper.GetFileExtension(n.Text).ToLowerInvariant().Equals(UiHelper.ZipExtension);
                 return false;
             }).Select(n =>
             {
@@ -457,7 +458,7 @@ namespace FileList.Models
         {
             (sender as TreeView).AfterCheck -= new TreeViewEventHandler(this.TreeView1_AfterCheck);
             string nodePath = FileListControl.GetNodePath(e.Node);
-            if (nodePath.ToLowerInvariant().Contains(UiHelper.ZipExtension) && !Path.GetExtension(nodePath).ToLowerInvariant().Equals(UiHelper.ZipExtension) && e.Node.Checked)
+            if (nodePath.ToLowerInvariant().Contains(UiHelper.ZipExtension) && !FileHelper.GetFileExtension(nodePath).ToLowerInvariant().Equals(UiHelper.ZipExtension) && e.Node.Checked)
             {
                 MessageBox.Show("Extracting zip files is not supported yet.\nSelect the actual zip to copy or move it", "", MessageBoxButtons.OK, MessageBoxIcon.Asterisk);
                 e.Node.Checked = false;
@@ -470,7 +471,7 @@ namespace FileList.Models
             }
             else
             {
-                if (Path.GetExtension(nodePath).Equals(UiHelper.ZipExtension))
+                if (FileHelper.GetFileExtension(nodePath).Equals(UiHelper.ZipExtension))
                 {
                     (sender as TreeView).AfterCheck += new TreeViewEventHandler(this.TreeView1_AfterCheck);
                     return;
@@ -1007,7 +1008,7 @@ namespace FileList.Models
         private bool ShouldNodeVisible(TreeNode node, IsParentNode isParent, ItemCheckEventArgs itemCheckEventArgs = null)
         {
             Func<FileData, bool> filterPredicate = this.GetFilterPredicate(itemCheckEventArgs);
-            string parentNodeName = System.IO.Path.GetDirectoryName(node.Name);
+            string parentNodeName = FileHelper.GetDirectoryName(node.Name);
             int maxNodes = this.treeView1.VisibleCount * 2;
 
             switch (isParent)

--- a/Views/MainForm.cs
+++ b/Views/MainForm.cs
@@ -30,8 +30,6 @@ namespace FileList.Views
             this.dialog = new Common.Models.Controls.FolderBrowserDialog(this);
             this.searchOptionsForm = new SearchOptionsForm();
             this.searchOptions = this.searchOptionsForm.SearchOption;// default(SearchOption);
-
-            UiHelper.InitiializeFilePreviewers();
         }
         private void BrowseButton_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
merge fixes for PathTooLongException and changes in win32 signatures and display file/folder names in browse previewer.